### PR TITLE
Added and tested flow-client authorization 

### DIFF
--- a/Classes/LROAuth2Client.h
+++ b/Classes/LROAuth2Client.h
@@ -10,6 +10,12 @@
 #import "ASIHTTPRequestDelegate.h"
 #import "LROAuth2ClientDelegate.h"
 
+
+typedef enum {
+    LROAuth2ServerSideFlow, //know as the authentication code flow in the specification
+    LROAuth2ClientSideFlow  //client-side (known as the implicit flow)
+} LROAuth2Flow; 
+
 @class LROAuth2AccessToken;
 
 @interface LROAuth2Client : NSObject <ASIHTTPRequestDelegate> {
@@ -23,9 +29,10 @@
   NSMutableArray *requests;
   id<LROAuth2ClientDelegate> delegate;
   BOOL debug;
-  
+  LROAuth2Flow authFlow;
  @private
-  BOOL isVerifying;   
+  BOOL isVerifying;  
+  
 }
 @property (nonatomic, copy) NSString *clientID;
 @property (nonatomic, copy) NSString *clientSecret;
@@ -36,6 +43,7 @@
 @property (nonatomic, readonly) LROAuth2AccessToken *accessToken;
 @property (nonatomic, assign) id<LROAuth2ClientDelegate> delegate;
 @property (nonatomic, assign) BOOL debug;
+@property (nonatomic, assign) LROAuth2Flow authFlow;
 
 - (id)initWithClientID:(NSString *)_clientID 
                 secret:(NSString *)_secret 
@@ -50,4 +58,5 @@
 - (void)authorizeUsingWebView:(UIWebView *)webView;
 - (void)authorizeUsingWebView:(UIWebView *)webView additionalParameters:(NSDictionary *)additionalParameters;
 - (void)extractAccessCodeFromCallbackURL:(NSURL *)url;
+- (void)extractAccessTokenFromCallbackURL:(NSURL *)url;
 @end

--- a/Classes/LROAuth2Client.m
+++ b/Classes/LROAuth2Client.m
@@ -6,7 +6,15 @@
 //  Copyright 2010 LJR Software Limited. All rights reserved.
 //
 
+// Ievgen Rudenko: Uncomment this to ise TouchJSON instead of YAJL
+//#define LROAUTH2_USE_TOUCHJSON
+
+
+#ifdef LROAUTH2_USE_TOUCHJSON
+#import "CJSONDeserializer.h"
+#else
 #import <YAJLIOS/NSObject+YAJL.h>
+#endif
 #import "LROAuth2Client.h"
 #import "ASIHTTPRequest.h"
 #import "NSURL+QueryInspector.h"
@@ -143,7 +151,11 @@
         NSLog(@"[oauth] finished verification request, %@ (%d)  %@", [request responseString], [request responseStatusCode], [request responseData]);
     }
     NSError *parseError = nil;
+#ifdef LROAUTH2_USE_TOUCHJSON
+    NSDictionary *authorizationData = [[CJSONDeserializer deserializer] deserializeAsDictionary:request.responseData error:&parseError];
+#else
     NSDictionary *authorizationData = [request.responseData yajl_JSON:&parseError];
+#endif
     if (parseError) {
         // try and decode the response body as a query string instead
         NSString *responseString = [[NSString alloc] initWithData:request.responseData encoding:NSUTF8StringEncoding];


### PR DESCRIPTION
I have made two changes:
1. Added Client Flow authorization (minus one request). In this case ASIHttp is not necessary ay all. 
http://tools.ietf.org/html/draft-ietf-oauth-v2-05#section-3.5
1. In server -flow you got data as ASIHTTP in "onData" method, but in this case it's possible that it's only the part of the data. I hace changed it, and put  the successfully response code to "on request done" delegate callback method. It's the right place for it.

I have tested it with you client Demo app and i's working like a charm.
Hope you accept my patch.
Also I'm going to use it not only with Facebook, but with some other OAuth2 enabled services: mail.ru and vkontakte. 
