### PR TITLE
Update the link to the blog post on auth2 for iPhone and iPad

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1,5 +1,5 @@
 # LROAuth2Client, OAuth2 client for iPhone/iPad
 
-Not much documentation here right now, but check out [my introductory blog post](http://lukeredpath.co.uk/blog/oauth2-for-iphone-and-ipad-applications.html).
+Not much documentation here right now, but check out [my introductory blog post](http://lukeredpath.co.uk/blog/2010/06/01/oauth2-for-iphone-and-ipad-applications/).
 
 A demo project can be found [here](http://github.com/lukeredpath/LROAuth2Demo).


### PR DESCRIPTION
Update the link to the blog post http://lukeredpath.co.uk/blog/2010/06/01/oauth2-for-iphone-and-ipad-applications/
